### PR TITLE
feat: filter exam responses

### DIFF
--- a/src/handlers/result.ts
+++ b/src/handlers/result.ts
@@ -57,6 +57,11 @@ export const getResults = factory.createHandlers(
             select: {
               code: true,
               is_multi_tier: true,
+              question_pack_question_banks: {
+                select: {
+                  question_bank_id: true,
+                },
+              },
             },
           },
           exam_responses: {
@@ -109,29 +114,35 @@ export const getResults = factory.createHandlers(
             email: result.users.email,
             schools: result.users.schools?.name,
           },
-          responses: result.exam_responses.map((response) => {
-            return {
-              questionId: Number(response.question_bank.id),
-              questionCode: response.question_bank.code,
-              optionId: Number(response.question_option?.id),
-              optionLabel: response.question_option?.label,
-              optionCorrect: response.question_option?.is_correct,
-              reasonId: Number(response.reason?.id),
-              reasonLabel: response.reason?.label,
-              reasonCorrect: response.reason?.is_correct,
-              points: countPoints(
-                response.question_option?.is_correct,
-                response.reason?.is_correct
-              ),
-              feedback:
-                response.question_bank.question_feedback.filter((feedback) => {
-                  return (
-                    feedback.score ===
-                    countPoints(response.question_option?.is_correct, response.reason?.is_correct)
-                  )
-                })[0]?.feedback || "",
-            }
-          }),
+          responses: result.exam_responses
+            .filter((response) => {
+              return result.question_packs.question_pack_question_banks.some((question) => {
+                return question.question_bank_id === response.question_bank.id
+              })
+            })
+            .map((response) => {
+              return {
+                questionId: Number(response.question_bank.id),
+                questionCode: response.question_bank.code,
+                optionId: Number(response.question_option?.id),
+                optionLabel: response.question_option?.label,
+                optionCorrect: response.question_option?.is_correct,
+                reasonId: Number(response.reason?.id),
+                reasonLabel: response.reason?.label,
+                reasonCorrect: response.reason?.is_correct,
+                points: countPoints(
+                  response.question_option?.is_correct,
+                  response.reason?.is_correct
+                ),
+                feedback:
+                  response.question_bank.question_feedback.filter((feedback) => {
+                    return (
+                      feedback.score ===
+                      countPoints(response.question_option?.is_correct, response.reason?.is_correct)
+                    )
+                  })[0]?.feedback || "",
+              }
+            }),
         }
       })
 


### PR DESCRIPTION
### Filter exam responses based on associated `question_bank_id`

This pull request includes changes to the `getResults` handler in the `src/handlers/result.ts` file to enhance the filtering and selection of exam responses based on question banks. The most important changes include adding a nested selection for `question_pack_question_banks` and filtering the `exam_responses` based on the `question_bank_id`.

Enhancements to `getResults` handler:

* [`src/handlers/result.ts`](diffhunk://#diff-ab0d5d512439d2d03808d45e13764aee6ef4c5250f5cda44c311aee312e5da0aR60-R64): Added nested selection for `question_pack_question_banks` to include `question_bank_id` in the selection.
* [`src/handlers/result.ts`](diffhunk://#diff-ab0d5d512439d2d03808d45e13764aee6ef4c5250f5cda44c311aee312e5da0aL112-R123): Modified the `responses` mapping to filter `exam_responses` by checking if the `question_bank_id` matches any in the `question_pack_question_banks`.