### PR TITLE
Improve `countPoints` logic

### DIFF
--- a/src/handlers/result.ts
+++ b/src/handlers/result.ts
@@ -132,15 +132,9 @@ export const getResults = factory.createHandlers(
                 reasonCorrect: response.reason?.is_correct,
                 points: countPoints(
                   response.question_option?.is_correct,
-                  response.reason?.is_correct
+                  response.reason?.is_correct,
+                  result.question_packs.is_multi_tier
                 ),
-                feedback:
-                  response.question_bank.question_feedback.filter((feedback) => {
-                    return (
-                      feedback.score ===
-                      countPoints(response.question_option?.is_correct, response.reason?.is_correct)
-                    )
-                  })[0]?.feedback || "",
               }
             }),
         }

--- a/src/utils/result.ts
+++ b/src/utils/result.ts
@@ -9,7 +9,11 @@
  * - 2 if optionValue is false or undefined and reasonValue is true.
  * - 1 if both optionValue and reasonValue are false or undefined.
  */
-export const countPoints = (optionValue: boolean | undefined, reasonValue: boolean | undefined) => {
+export const countPoints = (optionValue: boolean | undefined, reasonValue: boolean | undefined, isMultiTier = true) => {
+  if (!isMultiTier) {
+    return optionValue ? 1 : 0
+  }
+
   const resultCode = String(Number(optionValue || false)) + String(Number(reasonValue || false))
 
   switch (resultCode) {


### PR DESCRIPTION
This pull request includes changes to the `result` handling logic to accommodate multi-tier question packs. The most important changes involve updating the `countPoints` function and modifying the `getResults` handler to use this updated logic.

Improvements to result handling:

* [`src/utils/result.ts`](diffhunk://#diff-70042290c5987dad05b00bc5264b655486699bf113db1aa993029a27f3000ecaL12-R16): Updated the `countPoints` function to include an `isMultiTier` parameter, which adjusts the point calculation logic based on whether the question pack is multi-tier.
* [`src/handlers/result.ts`](diffhunk://#diff-ab0d5d512439d2d03808d45e13764aee6ef4c5250f5cda44c311aee312e5da0aL135-L143): Modified the `getResults` handler to pass the `isMultiTier` property from `result.question_packs` to the `countPoints` function.